### PR TITLE
filter valid permissions for sequences and use them in grant query

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN go mod download
 COPY main.go main.go
 COPY apis/ apis/
 COPY controllers/ controllers/
+COPY utility/ utility/
 
 # Build
 # the GOARCH has not a default value to allow the binary be built according to the host where the command

--- a/utility/privileges.go
+++ b/utility/privileges.go
@@ -1,0 +1,25 @@
+package utility
+
+import "strings"
+
+func GenerateSequencePrivileges(privileges string) string {
+
+	// map of valid privilges that can be granted on sequence
+	allowedPrivileges := map[string]struct{}{"SELECT": {}, "UPDATE": {}, "USAGE": {}}
+
+	// filtering the valid privileges
+	splitStrings := strings.Split(privileges, ",")
+
+	sequencePrivileges := make([]string, 0)
+	for _, str := range splitStrings {
+		trimmedStr := strings.TrimSpace(str)
+		_, ok := allowedPrivileges[trimmedStr]
+		if ok {
+			sequencePrivileges = append(sequencePrivileges, trimmedStr)
+		}
+	}
+
+	sequencePrivilegesStr := strings.Join(sequencePrivileges, ", ")
+
+	return sequencePrivilegesStr
+}

--- a/utility/privileges_test.go
+++ b/utility/privileges_test.go
@@ -1,0 +1,36 @@
+package utility
+
+import "testing"
+
+func TestGenerateSequencePrivileges(t *testing.T) {
+	type args struct {
+		privileges string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "test has sequence privileges",
+			args: args{
+				privileges: " INSERT   , SELECT,UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER, USAGE  ",
+			},
+			want: "SELECT, UPDATE, USAGE",
+		},
+		{
+			name: "test has no sequence privileges",
+			args: args{
+				privileges: " INSERT, DELETE, TRUNCATE, REFERENCES, TRIGGER",
+			},
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := GenerateSequencePrivileges(tt.args.privileges); got != tt.want {
+				t.Errorf("GenerateSequencePrivileges() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This pr fixes bug where postgresql operator fails to grant permission for sequences with the below error.
<img width="1206" alt="Screenshot 2024-12-20 at 4 36 17 PM" src="https://github.com/user-attachments/assets/e6217dda-cb15-4ed1-8834-fac9bf377642" />

Test Case:
Built the docker image in local and pushed to ecr, upon updating the image in deployment in aws-infra-dev-2, grant which was failing, got successfully created.

<img width="726" alt="Screenshot 2024-12-20 at 4 36 43 PM" src="https://github.com/user-attachments/assets/0e5e8da4-3cab-41a1-8370-4c682e0cd4d9" />
<img width="715" alt="Screenshot 2024-12-20 at 4 36 54 PM" src="https://github.com/user-attachments/assets/e6d34f50-fe6b-4d13-b385-827261213637" />
