### PR TITLE
initialize statements in prev state if empty

### DIFF
--- a/controllers/postgresql/grantstatement_controller.go
+++ b/controllers/postgresql/grantstatement_controller.go
@@ -241,11 +241,6 @@ func (r *GrantStatementReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 		return ctrl.Result{RequeueAfter: reconcileTime}, nil
 	}
 
-	// Update the previous state in the status
-	grantStatement.Status.PreviousGrantStatementState.Database = grantStatement.Spec.Database
-	grantStatement.Status.PreviousGrantStatementState.RoleRef = grantStatement.Spec.RoleRef
-	grantStatement.Status.PreviousGrantStatementState.Statements = grantStatement.Spec.Statements
-
 	r.appendGrantStatementStatusCondition(ctx, grantStatement, SUCCESS, metav1.ConditionTrue, GRANTSTATEMENT_EXECUTED, "Successfully executed grant statements")
 	logger.Info(fmt.Sprintf("Successfully executed grant statements for GrantStatement %s", grantStatement.Name))
 
@@ -375,6 +370,10 @@ func (r *GrantStatementReconciler) appendGrantStatementStatusCondition(ctx conte
 	if len(grantStatement.Status.Conditions) > 5 {
 		grantStatement.Status.Conditions = grantStatement.Status.Conditions[len(grantStatement.Status.Conditions)-5:]
 	}
+	// update previous state in the status
+	grantStatement.Status.PreviousGrantStatementState.Database = grantStatement.Spec.Database
+	grantStatement.Status.PreviousGrantStatementState.RoleRef = grantStatement.Spec.RoleRef
+	grantStatement.Status.PreviousGrantStatementState.Statements = grantStatement.Spec.Statements
 	err := r.Status().Update(ctx, grantStatement)
 	if err != nil {
 		logger.Error(err, fmt.Sprintf("Resource status update failed for GrantStatement %s", grantStatement.Name))


### PR DESCRIPTION
 The append status throws panic as in update method the prev state is not updated. To fix this I am updating the last status. Post the changes, the fail status can be seen in crd.

Error:


<img width="1440" alt="Screenshot 2025-02-27 at 11 20 57 PM" src="https://github.com/user-attachments/assets/55d4a07f-0b89-4372-b371-9559eb1c2045" />


Post fix:


<img width="1440" alt="Screenshot 2025-02-27 at 11 21 02 PM" src="https://github.com/user-attachments/assets/3910c9ef-9ab3-4d92-8ddb-ac51bf5b9e60" />